### PR TITLE
Fix some small things in the data chapter

### DIFF
--- a/content/data.md
+++ b/content/data.md
@@ -17,7 +17,7 @@ Our `TaskList` component as currently written is “presentational” (see [this
 
 This example uses [Redux](https://redux.js.org/), the most popular React library for storing data, to build a simple data model for our app. However, the pattern used here applies just as well to other data management libraries like [Apollo](https://www.apollographql.com/client/) and [MobX](https://mobx.js.org/).
 
-First we’ll construct a simple Redux store that responds to actions that change the state of tasks, in a file called `lib/redux.js` (intentionally kept simple):
+First we’ll construct a simple Redux store that responds to actions that change the state of tasks, in a file called `lib/redux.js` in the `src` folder (intentionally kept simple):
 
 ```javascript
 // A simple redux store/actions/reducer implementation.
@@ -71,7 +71,7 @@ const defaultTasks = [
 export default createStore(reducer, { tasks: defaultTasks });
 ```
 
-Then we’ll update the default export from the `TaskList` component to connect to the Redux store and render the tasks we are interested in
+Then we’ll update the default export from the `TaskList` component to connect to the Redux store and render the tasks we are interested in:
 
 ```javascript
 import React from 'react';
@@ -79,7 +79,7 @@ import PropTypes from 'prop-types';
 
 import Task from './Task';
 import { connect } from 'react-redux';
-import { archiveTask, pinTask, snoozeTask } from '../lib/redux';
+import { archiveTask, pinTask } from '../lib/redux';
 
 export function PureTaskList({ tasks, onPinTask, onArchiveTask }) {
   /* previous implementation of TaskList */


### PR DESCRIPTION
I'm walking through this now and noticed it wasn't specified that the `lib/redux.js` file shouldn't be in the root of the project, and also `snoozeTask` was imported but never used.

In addition:

- We never installed `redux` or `react-redux`, so we might want to add something about this
- The test we update at the bottom also mentions snoozing, which is a concept we haven't been introduced to at this point. We also haven't written this test yet, so something is up here (we've written a test that checks that pinned tasks appear at the start of the list)

I suspect some sections have been reordered. I didn't want to make any bigger changes without asking first though!