### PR TITLE
Provide fix for FSEvents.framework error

### DIFF
--- a/content/get-started.md
+++ b/content/get-started.md
@@ -36,6 +36,9 @@ yarn run storybook
 # Run the frontend app proper on port 3000:
 yarn start
 ```
+<div class="aside">
+NOTE: If `yarn test` throws an error, you may need to install `watchman` as advised in [this issue](https://github.com/facebook/create-react-app/issues/871#issuecomment-252297884
+</div>
 
 Our three frontend app modalities: automated test (Jest), component development (Storybook), and the app itself.
 


### PR DESCRIPTION
`yarn test` fails with `Error: Error watching file for changes: EMFILE` when watchman is unavailable.

Problem resolved with `brew install watchman` as detailed in the github issue