### PR TITLE
fix(data): restore missing prop on PureTaskList

### DIFF
--- a/content/react/en/data.md
+++ b/content/react/en/data.md
@@ -81,7 +81,7 @@ import Task from './Task';
 import { connect } from 'react-redux';
 import { archiveTask, pinTask } from '../lib/redux';
 
-export function PureTaskList({ tasks, onPinTask, onArchiveTask }) {
+export function PureTaskList({ loading, tasks, onPinTask, onArchiveTask }) {
   /* previous implementation of TaskList */
 }
 


### PR DESCRIPTION
The `PureTaskList` function is missing the `loading` prop in its destructuring